### PR TITLE
fix typo in font-family

### DIFF
--- a/part_07_fonts.html
+++ b/part_07_fonts.html
@@ -164,7 +164,7 @@ pre.borders {
 }
 </pre>
 <pre contenteditable style="font-size: 100%">body {
-  font-family: 'blah', arial, san-serif;
+  font-family: 'blah', arial, sans-serif;
 }</pre>
 
 </section>


### PR DESCRIPTION
fallback font-family is sans-serif not san-serif. https://developer.mozilla.org/en/docs/Web/CSS/font-family